### PR TITLE
refactor: consolidate canvas coordinate conversion

### DIFF
--- a/src/pages/bbyWorld.vue
+++ b/src/pages/bbyWorld.vue
@@ -195,7 +195,7 @@ import CardSwatchBar from '@/components/cardSwatchBar.vue';
 import { rand, seedRand } from '@/utils/rng';
 import { useSimulationSpeed } from '@/composables/useSimulationSpeed';
 import { resolveCardLabel, loadCardStamp } from '@/utils/cards';
-import { eventToCanvasCoords } from '@/utils/canvas';
+import { eventToCellCoords } from '@/utils/canvas';
 import { applyBoardSize as applyBoardSizeUtil } from '@/utils/board';
 
 // --- TIME & FORMATTING ---
@@ -425,8 +425,7 @@ async function loadSelectedImage(){
 function screenToWorld(e: MouseEvent): { x: number; y: number } | null {
   const c = gameCanvas.value;
   if (!c) return null;
-  const { x, y } = eventToCanvasCoords(c, e);
-  return { x: Math.floor(x), y: Math.floor(y) };
+  return eventToCellCoords(c, e);
 }
 function handleCanvasClick(e:MouseEvent){const c=screenToWorld(e); if(!c)return; const cell=spatialMap[I(c.x,c.y)]; if(cell?.alive){selectedCell.value=cell;}else{placeImageAt(c.x,c.y);}}
 function placeImageAt(wX:number,wY:number){if(!loadedImageData)return; const sX=wX-Math.floor(loadedImageData.width/2),sY=wY-Math.floor(loadedImageData.height/2); for(let y=0;y<loadedImageData.height;y++){for(let x=0;x<loadedImageData.width;x++){const i=(y*loadedImageData.width+x)*4,a=loadedImageData.data[i+3]; if(a>50){const pX=(sX+x+S())%S(),pY=(sY+y+S())%S(); if(!spatialMap[I(pX,pY)]){const[r,g,b]=[loadedImageData.data[i],loadedImageData.data[i+1],loadedImageData.data[i+2]]; const n=makeCell(pX,pY,r,g,b,a); livingCells.value.push(n); spatialMap[I(pX,pY)]=n;}}}}}

--- a/src/pages/bbyWorld1.vue
+++ b/src/pages/bbyWorld1.vue
@@ -168,7 +168,7 @@ import SpeedControls from '@/components/speedControls.vue';
 import CardSwatchBar from '@/components/cardSwatchBar.vue';
 import { rand, seedRand } from '@/utils/rng';
 import { useSimulationSpeed } from '@/composables/useSimulationSpeed';
-import { eventToCanvasCoords } from '@/utils/canvas';
+import { eventToCellCoords } from '@/utils/canvas';
 import { applyBoardSize as applyBoardSizeUtil } from '@/utils/board';
 
 // --- WORLD & UI STATE ---
@@ -565,8 +565,7 @@ async function loadSelectedImage() {
 function screenToWorld(event: MouseEvent): { x: number, y: number } | null {
     const canvas = gameCanvas.value;
     if (!canvas) return null;
-    const { x, y } = eventToCanvasCoords(canvas, event);
-    return { x: Math.floor(x), y: Math.floor(y) };
+    return eventToCellCoords(canvas, event);
 }
 
 function handleCanvasClick(event: MouseEvent) {

--- a/src/pages/bbyWorld2.vue
+++ b/src/pages/bbyWorld2.vue
@@ -196,7 +196,7 @@ import SpeedControls from '@/components/speedControls.vue';
 import CardSwatchBar from '@/components/cardSwatchBar.vue';
 import { useSimulationSpeed } from '@/composables/useSimulationSpeed';
 import { resolveCardLabel, loadCardStamp } from '@/utils/cards';
-import { eventToCanvasCoords } from '@/utils/canvas';
+import { eventToCellCoords } from '@/utils/canvas';
 import { clamp } from '@/utils/math';
 import { applyBoardSize as applyBoardSizeUtil } from '@/utils/board';
 
@@ -1304,9 +1304,7 @@ function makeCell(px:number,py:number,r:number,g:number,b:number,a:number, paren
 function placeImage(event: MouseEvent) {
   const canvas = gameCanvas.value; if (!canvas) return;
 
-  const { x: clickX, y: clickY } = eventToCanvasCoords(canvas, event);
-  const mouseGridX = Math.floor(clickX);
-  const mouseGridY = Math.floor(clickY);
+  const { x: mouseGridX, y: mouseGridY } = eventToCellCoords(canvas, event);
 
   const existing = spatialMap[I(mouseGridX, mouseGridY)];
   if (existing) {
@@ -2117,9 +2115,7 @@ const updateScope = throttle((event: MouseEvent) => {
   const scope = scopeCanvas.value;
   const box = scopeBox.value;
   if (!canvas || !scope || !box || !frameImg) return;
-  const { x: hxFloat, y: hyFloat } = eventToCanvasCoords(canvas, event);
-  const hx = Math.floor(hxFloat);
-  const hy = Math.floor(hyFloat);
+  const { x: hx, y: hy } = eventToCellCoords(canvas, event);
   const ctx = scope.getContext('2d');
   if (!ctx) return;
   const SCOPE_SIZE = 9;

--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -9,3 +9,12 @@ export function eventToCanvasCoords(canvas: HTMLCanvasElement, e: { clientX: num
     y: (e.clientY - rect.top) * scaleY,
   };
 }
+
+/**
+ * Convert a mouse event to integer cell coordinates on a canvas.
+ * Useful when dealing with grid-based canvases where each pixel maps to a cell.
+ */
+export function eventToCellCoords(canvas: HTMLCanvasElement, e: { clientX: number; clientY: number }): CanvasCoords {
+  const { x, y } = eventToCanvasCoords(canvas, e);
+  return { x: Math.floor(x), y: Math.floor(y) };
+}


### PR DESCRIPTION
## Summary
- add eventToCellCoords utility for converting mouse events to grid cells
- use shared utility across bbyWorld pages to remove duplicated rounding logic

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb2faf55488321ac62921530efc69d